### PR TITLE
Regular expression example wrong

### DIFF
--- a/_episodes/04-regular-expressions.md
+++ b/_episodes/04-regular-expressions.md
@@ -84,7 +84,7 @@ So, what is `^[Oo]rgani.e\b` going to match.
 Other useful special characters are:
 
 - `*` matches the preceding element zero or more times. For example, ab*c matches "ac", "abc", "abbbc", etc.
-- `+` matches the preceding element one or more times. For example, ab*c matches "abc", "abbbc" but not "ac".
+- `+` matches the preceding element one or more times. For example, ab+c matches "abc", "abbbc" but not "ac".
 - `?` matches when the preceding character appears zero or one time.
 - `{VALUE}` matches the preceding character the number of times define by VALUE; ranges can be specified with the syntax `{VALUE,VALUE}`
 - `|` means or.


### PR DESCRIPTION
Line 87 is incorrect. It should be ab+c and not ab*c in the example.

Please delete the text below before submitting your contribution. 

---



---
