### PR TITLE
02-jargon-busting.md - typo - missing word

### DIFF
--- a/_episodes/02-jargon-busting.md
+++ b/_episodes/02-jargon-busting.md
@@ -22,5 +22,5 @@ This group task is an opportunity for you to get help understanding terms, phras
 - Talk for 3 minutes (your instructor will be timing you!) on any terms, phrases, or ideas around code or software development in libraries that you've come across and perhaps feel you should know better.
 - Get into groups of 4-6. 
 - Make a list of all the problematic terms, phrases, and ideas each pair came up. Retain duplicates. Then - taking common words as a starting point - spend 10 minutes working together to try to explain what the terms, phrases, or ideas means (note: use both each other and the internet as a resource!). Make a note of those your group resolves and those you are still struggling with.
-- Each group then reports back on one issue resolved by their group and one issue not by their group.
+- Each group then reports back on one issue resolved by their group and one issue not resolved by their group.
 - The instructor will collate these on a whiteboard and facilitate a discussion about what we will cover today and where you can go for help on those things we won't cover.


### PR DESCRIPTION
Not sure if it is better to add in another "resolved" or reword like "one issue resolved by their group and one that was not."

